### PR TITLE
Add not-found-rapport naisjob for monthly Slack report

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,3 +162,48 @@ jobs:
           VAR: image=${{ needs.build.outputs.docker-image }}
           VARS: .nais/slett/prod.yaml
           PRINT_PAYLOAD: true
+
+  deploy-not-found-rapport-q1:
+    name: 'Deploy not-found-rapport to q1'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Calling nais deploy action for q1'
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/nais.yaml
+          VAR: image=${{ needs.build.outputs.docker-image }}
+          VARS: .nais/not-found-rapport/q1.yaml
+          PRINT_PAYLOAD: true
+
+  deploy-not-found-rapport-q2:
+    name: 'Deploy not-found-rapport to q2'
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Calling nais deploy action for q2'
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/nais.yaml
+          VAR: image=${{ needs.build.outputs.docker-image }}
+          VARS: .nais/not-found-rapport/q2.yaml
+          PRINT_PAYLOAD: true
+
+  deploy-not-found-rapport-prod:
+    name: 'Deploy not-found-rapport to prod'
+    runs-on: ubuntu-latest
+    needs: [build, deploy-not-found-rapport-q1, deploy-not-found-rapport-q2]
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Calling nais deploy action for prod'
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/nais.yaml
+          VAR: image=${{ needs.build.outputs.docker-image }}
+          VARS: .nais/not-found-rapport/prod.yaml
+          PRINT_PAYLOAD: true

--- a/.nais/not-found-rapport/prod.yaml
+++ b/.nais/not-found-rapport/prod.yaml
@@ -1,0 +1,11 @@
+name: eux-slett-usendte-rinasaker-not-found-rapport-naisjob
+schedule: "0 6 1 * *"
+
+sletteprosess: not-found-rapport
+
+application:
+  eux-slett-usendte-rinasaker:
+    name: eux-slett-usendte-rinasaker
+    namespace: eessibasis
+    endpoint: http://eux-slett-usendte-rinasaker
+    scope: api://prod-gcp.eessibasis.eux-slett-usendte-rinasaker/.default

--- a/.nais/not-found-rapport/q1.yaml
+++ b/.nais/not-found-rapport/q1.yaml
@@ -1,0 +1,11 @@
+name: eux-slett-usendte-rinasaker-not-found-rapport-naisjob-q1
+schedule: "0 6 1 * *"
+
+sletteprosess: not-found-rapport
+
+application:
+  eux-slett-usendte-rinasaker:
+    name: eux-slett-usendte-rinasaker-q1
+    namespace: eessibasis
+    endpoint: http://eux-slett-usendte-rinasaker-q1
+    scope: api://dev-gcp.eessibasis.eux-slett-usendte-rinasaker-q1/.default

--- a/.nais/not-found-rapport/q2.yaml
+++ b/.nais/not-found-rapport/q2.yaml
@@ -1,0 +1,11 @@
+name: eux-slett-usendte-rinasaker-not-found-rapport-naisjob-q2
+schedule: "0 6 1 * *"
+
+sletteprosess: not-found-rapport
+
+application:
+  eux-slett-usendte-rinasaker:
+    name: eux-slett-usendte-rinasaker-q2
+    namespace: eessibasis
+    endpoint: http://eux-slett-usendte-rinasaker-q2
+    scope: api://dev-gcp.eessibasis.eux-slett-usendte-rinasaker-q2/.default


### PR DESCRIPTION
Adds a new `not-found-rapport` naisjob that triggers the NOT_FOUND Slack report endpoint monthly.

### Changes

**New files:**
- `.nais/not-found-rapport/prod.yaml` — prod vars, cron `0 6 1 * *` (06:00 on the 1st of each month)
- `.nais/not-found-rapport/q1.yaml` — q1 vars
- `.nais/not-found-rapport/q2.yaml` — q2 vars

**Modified files:**
- `.github/workflows/release.yaml` — added deploy jobs for not-found-rapport (q1, q2, prod)

The naisjob calls `POST /api/v1/sletteprosess/not-found-rapport/execute` on `eux-slett-usendte-rinasaker`, which sends a Slack message listing any rinasaker with NOT_FOUND status from the previous month.

Depends on: navikt/eux-slett-usendte-rinasaker#11

Closes #2