### PR TITLE
Rename not-found-rapport naisjob to rapport

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,8 +163,8 @@ jobs:
           VARS: .nais/slett/prod.yaml
           PRINT_PAYLOAD: true
 
-  deploy-not-found-rapport-q1:
-    name: 'Deploy not-found-rapport to q1'
+  deploy-rapport-q1:
+    name: 'Deploy rapport to q1'
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -175,11 +175,11 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: .nais/nais.yaml
           VAR: image=${{ needs.build.outputs.docker-image }}
-          VARS: .nais/not-found-rapport/q1.yaml
+          VARS: .nais/rapport/q1.yaml
           PRINT_PAYLOAD: true
 
-  deploy-not-found-rapport-q2:
-    name: 'Deploy not-found-rapport to q2'
+  deploy-rapport-q2:
+    name: 'Deploy rapport to q2'
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -190,13 +190,13 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: .nais/nais.yaml
           VAR: image=${{ needs.build.outputs.docker-image }}
-          VARS: .nais/not-found-rapport/q2.yaml
+          VARS: .nais/rapport/q2.yaml
           PRINT_PAYLOAD: true
 
-  deploy-not-found-rapport-prod:
-    name: 'Deploy not-found-rapport to prod'
+  deploy-rapport-prod:
+    name: 'Deploy rapport to prod'
     runs-on: ubuntu-latest
-    needs: [build, deploy-not-found-rapport-q1, deploy-not-found-rapport-q2]
+    needs: [build, deploy-rapport-q1, deploy-rapport-q2]
     steps:
       - uses: actions/checkout@v4
       - name: 'Calling nais deploy action for prod'
@@ -205,5 +205,5 @@ jobs:
           CLUSTER: prod-gcp
           RESOURCE: .nais/nais.yaml
           VAR: image=${{ needs.build.outputs.docker-image }}
-          VARS: .nais/not-found-rapport/prod.yaml
+          VARS: .nais/rapport/prod.yaml
           PRINT_PAYLOAD: true

--- a/.nais/rapport/prod.yaml
+++ b/.nais/rapport/prod.yaml
@@ -1,7 +1,7 @@
-name: eux-slett-usendte-rinasaker-not-found-rapport-naisjob
+name: eux-slett-usendte-rinasaker-rapport-naisjob
 schedule: "0 6 1 * *"
 
-sletteprosess: not-found-rapport
+sletteprosess: rapport
 
 application:
   eux-slett-usendte-rinasaker:

--- a/.nais/rapport/q1.yaml
+++ b/.nais/rapport/q1.yaml
@@ -1,7 +1,7 @@
-name: eux-slett-usendte-rinasaker-not-found-rapport-naisjob-q1
+name: eux-slett-usendte-rinasaker-rapport-naisjob-q1
 schedule: "0 6 1 * *"
 
-sletteprosess: not-found-rapport
+sletteprosess: rapport
 
 application:
   eux-slett-usendte-rinasaker:

--- a/.nais/rapport/q2.yaml
+++ b/.nais/rapport/q2.yaml
@@ -1,7 +1,7 @@
-name: eux-slett-usendte-rinasaker-not-found-rapport-naisjob-q2
+name: eux-slett-usendte-rinasaker-rapport-naisjob-q2
 schedule: "0 6 1 * *"
 
-sletteprosess: not-found-rapport
+sletteprosess: rapport
 
 application:
   eux-slett-usendte-rinasaker:


### PR DESCRIPTION
Closes #4

Renames the `not-found-rapport` naisjob to `rapport` to match the updated API endpoint in the main application (navikt/eux-slett-usendte-rinasaker#15).

### Changes
- Renamed `.nais/not-found-rapport/` → `.nais/rapport/` (prod, q1, q2)
- Updated naisjob names: `*-not-found-rapport-naisjob*` → `*-rapport-naisjob*`
- Updated `sletteprosess: not-found-rapport` → `sletteprosess: rapport`
- Updated GitHub Actions workflow deploy jobs accordingly

### Post-merge cleanup
After deploying, delete the old naisjobs from NAIS clusters:
```bash
kubectl delete naisjob eux-slett-usendte-rinasaker-not-found-rapport-naisjob -n eessibasis
```