### PR TITLE
chore: bump parent-pom, chainguard base image, dependabot og node24 actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 6
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 4
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "navikt/eessibasis"
+    labels:
+      - "dependencies"
+      - "automerge"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'temurin'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up java 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: 'temurin'
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q1'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q1'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q2'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q2'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -138,7 +138,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, deploy-til-sletting-q1, deploy-til-sletting-q2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for prod'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -153,7 +153,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, deploy-slett-q1, deploy-slett-q2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for prod'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q1'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for q2'
         uses: nais/deploy/actions/deploy@v2
         env:
@@ -198,7 +198,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, deploy-rapport-q1, deploy-rapport-q2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: 'Calling nais deploy action for prod'
         uses: nais/deploy/actions/deploy@v2
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/java25
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 COPY target/eux-slett-usendte-rinasaker-naisjob.jar /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.10</version>
+        <version>2.0.15</version>
     </parent>
 
     <groupId>no.nav.eux.slett.usendte.rinasaker.naisjob</groupId>


### PR DESCRIPTION
## Endringer

- **`chore(deps)`** Bump parent-pom fra 2.0.10 til 2.0.15
- **`chore(docker)`** Bytt base image fra `gcr.io/distroless/java25` til Chainguard (`europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25`)
- **`ci(deps)`** Legg til Dependabot-konfigurasjon for Maven (daglig, cooldown, automerge)
- **`ci`** Bump GitHub Actions til Node 24-versjoner: `actions/checkout@v7`, `actions/setup-java@v5`

## Sjekkliste
- [x] Konvensjonelle commit-meldinger
- [x] Ingen funksjonelle endringer